### PR TITLE
fix: Trailhead bug TCF-026086

### DIFF
--- a/apps/ready-to-fly/config/config.js
+++ b/apps/ready-to-fly/config/config.js
@@ -23,11 +23,16 @@ requiredEnvVars.forEach((envVar) => {
 
 const defaultSalesforceApiVersion = '54.0';
 
+const privateKeyBase64Decoded = Buffer.from(
+    process.env.PRIVATE_KEY,
+    'base64'
+).toString('ascii');
+
 const salesforce = {
     clientId: process.env.SF_CLIENT_ID,
     clientSecret: process.env.SF_CLIENT_SECRET,
     herokuUrl: process.env.HEROKU_URL,
-    privateKey: process.env.PRIVATE_KEY,
+    privateKey: privateKeyBase64Decoded,
     loginUrl: process.env.SF_LOGIN_URL,
     username: process.env.SF_USERNAME,
     apiVersion: process.env.SF_API_VERSION || defaultSalesforceApiVersion

--- a/scripts/deploy/setup-heroku-app.js
+++ b/scripts/deploy/setup-heroku-app.js
@@ -53,6 +53,10 @@ const setupHerokuApp = () => {
     );
 
     log('*** Writing .env file for local development');
+    // Base64 encode the PRIVATE_KEY
+    const privateKeyBase64Encode = Buffer.from(sh.env.PRIVATE_KEY).toString(
+        'base64'
+    );
     // Env variables for Slack Auth
     fs.writeFileSync('.env', ''); // empty the .env file for fresh write
     fs.appendFileSync(
@@ -85,7 +89,7 @@ const setupHerokuApp = () => {
     log('*** Pushing app to Heroku');
     log('*** Setting remote configuration parameters');
     sh.exec(
-        `heroku config:set PRIVATE_KEY="${sh.env.PRIVATE_KEY}" -a ${sh.env.HEROKU_APP_NAME}`,
+        `heroku config:set PRIVATE_KEY=${privateKeyBase64Encode} -a ${sh.env.HEROKU_APP_NAME}`,
         { silent: true }
     );
     // Needed by buildpack


### PR DESCRIPTION
### What does this PR do?

fix for Trailhead issue **TCF-026086**.

The command `heroku config:set PRIVATE_KEY="${sh.env.PRIVATE_KEY}" -a ${sh.env.HEROKU_APP_NAME} `fails in windows OS.

I did a debug in the windows machine and turns out the problem is too deep in the Heroku config command, not able to consider multiline environment variable.

I have reworked this to now simply use a base64 encoding that turns a multiline string into a single line string. This approach works in all the Operating systems including windows OSX.


### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
