### PR TITLE
fix: use base64 encode for local dev

### DIFF
--- a/scripts/deploy/setup-heroku-app.js
+++ b/scripts/deploy/setup-heroku-app.js
@@ -78,13 +78,7 @@ const setupHerokuApp = () => {
     );
     fs.appendFileSync('.env', 'AES_KEY=' + sh.env.AES_KEY + '\r\n');
     fs.appendFileSync('.env', 'HMAC_KEY=' + sh.env.HMAC_KEY + '\r\n');
-    fs.appendFileSync(
-        '.env',
-        'PRIVATE_KEY=' +
-            '"' +
-            sh.env.PRIVATE_KEY.replace(/(\r\n|\r|\n)/g, '\\n') +
-            '"'
-    );
+    fs.appendFileSync('.env', 'PRIVATE_KEY=' + privateKeyBase64Encode);
 
     log('*** Pushing app to Heroku');
     log('*** Setting remote configuration parameters');


### PR DESCRIPTION
### What does this PR do?

This is part of the **TCF026086** bug. It now makes sure even for local dev we store the environment variable base64 encode to stay consistent.

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
