### PR TITLE
feat: update instructions to use git version => 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To be able to run this project you will need:
     -   Optional: If you want to use scratch orgs follow the [instructions](https://help.salesforce.com/articleView?id=sfdx_setup_enable_devhub.htm&type=5) to enable Dev Hub in your Salesforce Developer Org.
 -   A new Slack workspace. You will need to create this workspace through a personal Slack account. (instructions [here](https://slack.com/help/articles/206845317-Create-a-Slack-workspace))
 -   Heroku account ([signup for free](https://signup.heroku.com))
--   `git` (download [here](https://git-scm.com/downloads))
+-   `git` >= 1.22 (download [here](https://git-scm.com/downloads))
 -   `node` >= 14 (download [here](https://nodejs.org/en/download/))
 -   `sfdx` CLI >= sfdx-cli/7.142.0 (download [here](https://developer.salesforce.com/tools/sfdxcli))
 -   `heroku` CLI (download [here](https://devcenter.heroku.com/articles/heroku-cli))


### PR DESCRIPTION
### What does this PR do?

Update readme instructions to use git version => 1.22

### What issues does this PR fix or reference?

The Trailhead testing team raised this as one of the end users had an older version of git, and the command `git branch --show-current` in the [deploy script ](https://github.com/trailheadapps/ready-to-fly/blob/9733603951a75c4a0b89122c651e506df0cf7a3b/scripts/deploy.js#L28)does not work.  

Check **TCF-027405** in GUS


## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
